### PR TITLE
Rename bool to boolean since bool is now a type in C (until C99...)

### DIFF
--- a/tclxml.c
+++ b/tclxml.c
@@ -1580,7 +1580,7 @@ TclXMLInstanceConfigure (interp, xmlinfo, objc, objv)
      int objc;
      Tcl_Obj *CONST objv[];
 {
-  int index, bool, doParse = 0, result;
+  int index, boolean, doParse = 0, result;
   TclXML_ParserClassInfo *classinfo = (TclXML_ParserClassInfo *) xmlinfo->parserClass;
 
   while (objc > 1) {
@@ -1639,14 +1639,14 @@ TclXMLInstanceConfigure (interp, xmlinfo, objc, objv)
     switch ((enum instanceConfigureSwitches) index) {
       case TCLXML_FINAL:            /* -final */
 
-        if (Tcl_GetBooleanFromObj(interp, objv[1], &bool) != TCL_OK) {
+        if (Tcl_GetBooleanFromObj(interp, objv[1], &boolean) != TCL_OK) {
           return TCL_ERROR;
         }
 
-        if (bool && !xmlinfo->final) {
+        if (boolean && !xmlinfo->final) {
           doParse = 1;
 
-        } else if (!bool && xmlinfo->final) {
+        } else if (!boolean && xmlinfo->final) {
           /*
            * Reset the parser for new input
            */
@@ -1654,7 +1654,7 @@ TclXMLInstanceConfigure (interp, xmlinfo, objc, objv)
           TclXMLResetParser(interp, xmlinfo);
           doParse = 0;
         }
-        xmlinfo->final = bool;
+        xmlinfo->final = boolean;
         break;
 
 	  case TCLXML_ENCODING: /* -encoding */
@@ -1666,14 +1666,14 @@ TclXMLInstanceConfigure (interp, xmlinfo, objc, objv)
 		break;
 
       case TCLXML_VALIDATE:         /* -validate */
-        if (Tcl_GetBooleanFromObj(interp, objv[1], &bool) != TCL_OK) {
+        if (Tcl_GetBooleanFromObj(interp, objv[1], &boolean) != TCL_OK) {
           return TCL_ERROR;
         }
         /*
          * If the parser is in the middle of parsing a document,
          * this will be ignored.  Perhaps an error should be returned?
          */
-        xmlinfo->validate = bool;
+        xmlinfo->validate = boolean;
         break;
 
     case TCLXML_BASEURL:             /* -baseurl, -baseuri */
@@ -1688,10 +1688,10 @@ TclXMLInstanceConfigure (interp, xmlinfo, objc, objv)
 
       case TCLXML_DEFAULTEXPANDINTERNALENTITIES:    /* -defaultexpandinternalentities */
         /* ericm@scriptics */
-        if (Tcl_GetBooleanFromObj(interp, objv[1], &bool) != TCL_OK) {
+        if (Tcl_GetBooleanFromObj(interp, objv[1], &boolean) != TCL_OK) {
           return TCL_ERROR;
         }
-        xmlinfo->expandinternalentities = bool;
+        xmlinfo->expandinternalentities = boolean;
         break;
 
       case TCLXML_PARAMENTITYPARSING:

--- a/tclxslt-libxslt.c
+++ b/tclxslt-libxslt.c
@@ -1565,10 +1565,10 @@ TclXSLT_ConvertTclObjToXPathObj(interp, objPtr)
       return NULL;
     }
   } else if (objPtr->typePtr == Tcl_GetObjType("boolean")) {
-    int bool;
+    int boolean;
 
-    if (Tcl_GetBooleanFromObj(interp, objPtr, &bool) == TCL_OK) {
-      return xmlXPathNewBoolean(bool);
+    if (Tcl_GetBooleanFromObj(interp, objPtr, &boolean) == TCL_OK) {
+      return xmlXPathNewBoolean(boolean);
     } else {
       return NULL;
     }


### PR DESCRIPTION
With the last version of gcc, I can't compile tclxml anymore because it named variables _bool_ and bool is now a data type.
So I simply renamed bool to boolean in code.

If you can create a new tag/version.